### PR TITLE
Disable permessage-deflate, limit payloads to 1kb

### DIFF
--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -171,7 +171,8 @@ GameServer.prototype.start = function() {
     }
     var wsOptions = {
         server: this.httpServer, 
-        perMessageDeflate: true
+        perMessageDeflate: false,
+        maxPayload: 1024
     };
     this.wsServer = new WebSocket.Server(wsOptions);
     this.wsServer.on('error', this.onServerSocketError.bind(this));


### PR DESCRIPTION
* Permessage-deflate is very CPU consuming and shouldn't really be used in a game server. Disabling it will increase throughput a lot.
* Limiting message payload to 1kb should be enough for all game messages, and better limit sabotage.